### PR TITLE
Flush all (from header menu) now flushes all WPML registered domains too

### DIFF
--- a/wordpress/varnish-cache/class/cache/class.instance.php
+++ b/wordpress/varnish-cache/class/cache/class.instance.php
@@ -43,7 +43,7 @@ abstract class XLII_Cache_Instance extends XLII_Cache_Singleton
 		if ( function_exists('icl_object_id') ) {
 			$success = true;
 			foreach(icl_get_languages() as $lang) {
-				$success = ($this->delete($lang['url'] . '/.*') && $success ? true : false);
+				$success = ((substr($lang['url'], -1) === '/' ? $this->delete(substr($lang['url'], 0, -1) . '/.*') : $this->delete($lang['url'] . '/.*')) && $success ? true : false);
 			}
 			return $success;
 		}

--- a/wordpress/varnish-cache/class/cache/class.instance.php
+++ b/wordpress/varnish-cache/class/cache/class.instance.php
@@ -41,7 +41,7 @@ abstract class XLII_Cache_Instance extends XLII_Cache_Singleton
 	{
 		// Get all WPML domains
 		if ( function_exists('icl_object_id') ) {
-			$success = false;
+			$success = true;
 			foreach(icl_get_languages() as $lang) {
 				$success = ($this->delete($lang['url'] . '/.*') && $success ? true : false);
 			}

--- a/wordpress/varnish-cache/class/cache/class.instance.php
+++ b/wordpress/varnish-cache/class/cache/class.instance.php
@@ -32,12 +32,24 @@ abstract class XLII_Cache_Instance extends XLII_Cache_Singleton
 	
 	/**
 	 * Flush the entire cache.
+	 *
+	 * When WPML is activated, all WPML domains are gathered and flushed one by one
 	 * 
 	 * @return	bool
 	 */ 
 	public function flush()
 	{
-		return $this->delete(home_url('/.*'));
+		// Get all WPML domains
+		if ( function_exists('icl_object_id') ) {
+			$success = false;
+			foreach(icl_get_languages() as $lang) {
+				$success = ($this->delete($lang['url'] . '/.*') && $success ? true : false);
+			}
+			return $success;
+		}
+		else {
+			return $this->delete(home_url('/.*'));
+		}
 	}
 	
 	/**


### PR DESCRIPTION
One of my clients was using this plugin but also had WPML activated and runs two domains on your servers: *.nl & *.de. Using the flush all button on top of the WP admin, only the *.nl got flushed due to the usage of home_url(). I changed things a bit to be able to use all WPML registered domains also in the flush all function.

I didn't adjust other functions yet, but clearly there are more places that could use this change as I see more usage of home_url(). Problem is that e.g. at Post Observer you also need to figure out which domain the post belongs to and use the correct URL for it to register. Option could be to implement at any flush all the registered domains ofcourse.

For now this is the fix that suits my client and I hope you can also use it. 
